### PR TITLE
Buscar «magonismo»

### DIFF
--- a/SPARQL/magonismo
+++ b/SPARQL/magonismo
@@ -1,0 +1,7 @@
+#Magonismo
+SELECT ?item ?itemLabel 
+WHERE 
+{
+  ?item wdt:P1142 wd:Q10323082. # Ideologia politica: magonismo
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],es". } #preferencia en español
+}


### PR DESCRIPTION
Consulta de elementos que tengan como 'ideología política' el «Magonismo»

Generado dentro del "Taller Wikidata" impartido por @silviaegt